### PR TITLE
#29 - Make studies serializable

### DIFF
--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/AnnotationStudy.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/AnnotationStudy.java
@@ -19,6 +19,7 @@ package org.dkpro.statistics.agreement;
 
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -30,8 +31,9 @@ import java.util.Set;
 public abstract class AnnotationStudy
     implements IAnnotationStudy
 {
-
-    protected ArrayList<String> raters;
+    private static final long serialVersionUID = -3596722258510421730L;
+    
+    protected List<String> raters;
     protected Set<Object> categories;
 
     protected AnnotationStudy()

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/AnnotationUnit.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/AnnotationUnit.java
@@ -28,7 +28,8 @@ package org.dkpro.statistics.agreement;
 public class AnnotationUnit
     implements IAnnotationUnit
 {
-
+    private static final long serialVersionUID = 4277733312128063453L;
+    
     protected int raterIdx;
     protected Object category;
 

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/IAnnotationItem.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/IAnnotationItem.java
@@ -17,6 +17,8 @@
  */
 package org.dkpro.statistics.agreement;
 
+import java.io.Serializable;
+
 /**
  * Represents a single annotation item of an {@link IAnnotationStudy}. Note that the definition of
  * an annotation item depends on the annotation setup: In coding tasks, annotation items are fixed,
@@ -31,7 +33,7 @@ package org.dkpro.statistics.agreement;
  * @see IAnnotationStudy
  * @author Christian M. Meyer
  */
-public interface IAnnotationItem
+public interface IAnnotationItem extends Serializable
 {
 
 }

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/IAnnotationStudy.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/IAnnotationStudy.java
@@ -17,6 +17,8 @@
  */
 package org.dkpro.statistics.agreement;
 
+import java.io.Serializable;
+
 /**
  * Basic interface representing the essential data model of any annotation study. The data model
  * provides access to the raters participating in the annotation study, the set of categories a
@@ -31,12 +33,15 @@ package org.dkpro.statistics.agreement;
  * @author Christian M. Meyer
  */
 public interface IAnnotationStudy
+    extends Serializable
 {
 
     // -- Raters --
 
     /** Returns the number of raters participating in this study. */
-    public int getRaterCount();
+    int getRaterCount();
+    
+    int findRater(final String name);
 
     // -- Categories --
 
@@ -45,20 +50,20 @@ public interface IAnnotationStudy
      * are not per se clear; they might need to be gathered by iterating through all associated
      * items, which yields performance problems in large-scale annotation studies.
      */
-    public Iterable<Object> getCategories();
+    Iterable<Object> getCategories();
 
     /**
      * Returns the number of annotation categories in the study. Note that the categories are not
      * per se clear; they might need to be gathered by iterating through all associated items, which
      * yields performance problems in large-scale annotation studies.
      */
-    public int getCategoryCount();
+    int getCategoryCount();
 
     /**
      * Returns true if, and only if, the categories defined by the study yield a dichotomy (i.e.,
      * there are exactly two categories).
      */
-    public boolean isDichotomous();
+    boolean isDichotomous();
 
     // -- Units --
 
@@ -68,6 +73,5 @@ public interface IAnnotationStudy
      * Returns the number of annotation units defined by the study. That is, the number of
      * annotations coded by the raters.
      */
-    public int getUnitCount();
-
+    int getUnitCount();
 }

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/IAnnotationUnit.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/IAnnotationUnit.java
@@ -17,6 +17,8 @@
  */
 package org.dkpro.statistics.agreement;
 
+import java.io.Serializable;
+
 /**
  * Represents a single annotation unit of an {@link IAnnotationStudy} identified and coded by a
  * certain rater. This basic interface concentrates on modeling the rater (represented by its
@@ -28,6 +30,7 @@ package org.dkpro.statistics.agreement;
  * @author Christian M. Meyer
  */
 public interface IAnnotationUnit
+    extends Serializable
 {
     /**
      * Returns the index of the rater who coded this unit (in case of a coding study) or defined the

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/coding/CodingAnnotationItem.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/coding/CodingAnnotationItem.java
@@ -35,7 +35,8 @@ import org.dkpro.statistics.agreement.IAnnotationUnit;
 public class CodingAnnotationItem
     implements ICodingAnnotationItem
 {
-
+    private static final long serialVersionUID = 3447650373912260846L;
+    
     protected List<IAnnotationUnit> units;
     protected int nonNullCount;
 

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/coding/CodingAnnotationStudy.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/coding/CodingAnnotationStudy.java
@@ -17,6 +17,7 @@
  */
 package org.dkpro.statistics.agreement.coding;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -41,9 +42,10 @@ import org.dkpro.statistics.agreement.IAnnotationUnit;
  */
 public class CodingAnnotationStudy
     extends AnnotationStudy
-    implements ICodingAnnotationStudy, Cloneable
+    implements ICodingAnnotationStudy, Cloneable, Serializable
 {
-
+    private static final long serialVersionUID = -8242222160334337626L;
+    
     protected List<ICodingAnnotationItem> items;
 
     /**

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/unitizing/IUnitizingAnnotationStudy.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/unitizing/IUnitizingAnnotationStudy.java
@@ -17,6 +17,8 @@
  */
 package org.dkpro.statistics.agreement.unitizing;
 
+import java.util.Collection;
+
 import org.dkpro.statistics.agreement.IAnnotationStudy;
 
 /**
@@ -39,7 +41,7 @@ public interface IUnitizingAnnotationStudy
     // -- Units --
 
     /** Allows iterating all annotation units of this study. */
-    public Iterable<IUnitizingAnnotationUnit> getUnits();
+    Collection<IUnitizingAnnotationUnit> getUnits();
 
     // -- Continuum --
 
@@ -53,13 +55,18 @@ public interface IUnitizingAnnotationStudy
      * Returns the begin of the continuum (i.e., the first offset that is considered valid for
      * annotation units).
      */
-    public long getContinuumBegin();
+    long getContinuumBegin();
 
     /**
      * Returns the length of the continuum (i.e., the last possible right delimiter of an annotation
      * unit).
      */
-    public long getContinuumLength();
+    long getContinuumLength();
+
+    /**
+     * Returns the number of units rated by the given rater.
+     */
+    long getUnitCount(int aRaterIdx);
 
     // TODO: public void addSectionBoundary(long position);
 

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/unitizing/UnitizingAnnotationStudy.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/unitizing/UnitizingAnnotationStudy.java
@@ -17,6 +17,8 @@
  */
 package org.dkpro.statistics.agreement.unitizing;
 
+import java.io.Serializable;
+import java.util.Collection;
 import java.util.Iterator;
 import java.util.Set;
 import java.util.TreeSet;
@@ -36,13 +38,25 @@ import org.dkpro.statistics.agreement.AnnotationStudy;
  */
 public class UnitizingAnnotationStudy
     extends AnnotationStudy
-    implements IUnitizingAnnotationStudy
+    implements IUnitizingAnnotationStudy, Serializable
 {
-
+    private static final long serialVersionUID = 5877774485360119115L;
+    
     protected Set<IUnitizingAnnotationUnit> units;
     protected long begin;
     protected long length;
     // protected Set<Integer> sections;
+
+    /**
+     * Initializes and empty annotation study for a unitizing task with no raters. Add raters using
+     * the {@link #addRater(String)} method. The basic setup of a unitizing study is identifying
+     * units within a given continuum. The continuum is initialized to start at position 0 and end
+     * at the given length.
+     */
+    public UnitizingAnnotationStudy(int length)
+    {
+        this(0, 0, length);
+    }
 
     /**
      * Initializes and empty annotation study for a unitizing task with the given number of raters.
@@ -111,9 +125,15 @@ public class UnitizingAnnotationStudy
     }
 
     @Override
-    public Iterable<IUnitizingAnnotationUnit> getUnits()
+    public Collection<IUnitizingAnnotationUnit> getUnits()
     {
         return units;
+    }
+    
+    @Override
+    public long getUnitCount(int raterIdx)
+    {
+        return units.stream().filter(u -> u.getRaterIdx() == raterIdx).count();
     }
 
     @Override

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/unitizing/UnitizingAnnotationUnit.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/unitizing/UnitizingAnnotationUnit.java
@@ -34,7 +34,8 @@ public class UnitizingAnnotationUnit
     extends AnnotationUnit
     implements IUnitizingAnnotationUnit
 {
-
+    private static final long serialVersionUID = -6716379300031576772L;
+    
     protected long offset;
     protected long length;
 


### PR DESCRIPTION
- Make the studies and their data classes serializable
- getUnits returns Collection instead of Iterable to facilitate usage with new Java streaming API