### PR TITLE
while print the entire study, use equals() on categories comparison instead of ==

### DIFF
--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/visualization/UnitizingMatrixPrinter.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/visualization/UnitizingMatrixPrinter.java
@@ -18,6 +18,7 @@
 package org.dkpro.statistics.agreement.visualization;
 
 import java.io.PrintStream;
+import java.util.Objects;
 
 import org.dkpro.statistics.agreement.unitizing.IUnitizingAnnotationStudy;
 import org.dkpro.statistics.agreement.unitizing.IUnitizingAnnotationUnit;
@@ -90,7 +91,7 @@ public class UnitizingMatrixPrinter
             annotations1[i] = ' ';
         }
         for (IUnitizingAnnotationUnit unit : study.getUnits()) {
-            if (unit.getRaterIdx() == rater1 && unit.getCategory().equals(category)) {
+            if (unit.getRaterIdx() == rater1 && Objects.equals(unit.getCategory(), category)) {
                 for (int i = 0; i < unit.getLength(); i++) {
                     annotations1[i + (int) unit.getOffset() - (int) B] = '*';
                 }
@@ -106,7 +107,7 @@ public class UnitizingMatrixPrinter
             annotations2[i] = ' ';
         }
         for (IUnitizingAnnotationUnit unit : study.getUnits()) {
-            if (unit.getRaterIdx() == rater2 && unit.getCategory().equals(category)) {
+            if (unit.getRaterIdx() == rater2 && Objects.equals(unit.getCategory(), category)) {
                 for (int i = 0; i < unit.getLength(); i++) {
                     annotations2[i + (int) unit.getOffset() - (int) B] = '*';
                 }

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/visualization/UnitizingMatrixPrinter.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/visualization/UnitizingMatrixPrinter.java
@@ -90,7 +90,7 @@ public class UnitizingMatrixPrinter
             annotations1[i] = ' ';
         }
         for (IUnitizingAnnotationUnit unit : study.getUnits()) {
-            if (unit.getRaterIdx() == rater1 && unit.getCategory() == category) {
+            if (unit.getRaterIdx() == rater1 && unit.getCategory().equals(category)) {
                 for (int i = 0; i < unit.getLength(); i++) {
                     annotations1[i + (int) unit.getOffset() - (int) B] = '*';
                 }
@@ -106,7 +106,7 @@ public class UnitizingMatrixPrinter
             annotations2[i] = ' ';
         }
         for (IUnitizingAnnotationUnit unit : study.getUnits()) {
-            if (unit.getRaterIdx() == rater2 && unit.getCategory() == category) {
+            if (unit.getRaterIdx() == rater2 && unit.getCategory().equals(category)) {
                 for (int i = 0; i < unit.getLength(); i++) {
                     annotations2[i + (int) unit.getOffset() - (int) B] = '*';
                 }

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/visualization/UnitizingStudyPrinter.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/visualization/UnitizingStudyPrinter.java
@@ -18,6 +18,7 @@
 package org.dkpro.statistics.agreement.visualization;
 
 import java.io.PrintStream;
+import java.util.Objects;
 
 import org.dkpro.statistics.agreement.unitizing.IUnitizingAnnotationStudy;
 import org.dkpro.statistics.agreement.unitizing.IUnitizingAnnotationUnit;
@@ -109,7 +110,7 @@ public class UnitizingStudyPrinter
             annotations[i] = ' ';
         }
         for (IUnitizingAnnotationUnit unit : study.getUnits()) {
-            if (unit.getRaterIdx() == raterIdx && unit.getCategory().equals(category)) {
+            if (unit.getRaterIdx() == raterIdx && Objects.equals(unit.getCategory(),category)) {
                 for (int i = 0; i < unit.getLength(); i++) {
                     annotations[i + (int) unit.getOffset() - (int) B] = '*';
                 }

--- a/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/visualization/UnitizingStudyPrinter.java
+++ b/dkpro-statistics-agreement/src/main/java/org/dkpro/statistics/agreement/visualization/UnitizingStudyPrinter.java
@@ -109,7 +109,7 @@ public class UnitizingStudyPrinter
             annotations[i] = ' ';
         }
         for (IUnitizingAnnotationUnit unit : study.getUnits()) {
-            if (unit.getRaterIdx() == raterIdx && unit.getCategory() == category) {
+            if (unit.getRaterIdx() == raterIdx && unit.getCategory().equals(category)) {
                 for (int i = 0; i < unit.getLength(); i++) {
                     annotations[i + (int) unit.getOffset() - (int) B] = '*';
                 }


### PR DESCRIPTION
This fix attempt to solve when the categories are strings that are extracted and they could lead to different objects. 
The check on the iterator for constructing the comparison matrix over the continuous, using `==` was too restrictive.
I'm not sure whether there is a reason for that. 